### PR TITLE
mengubah pre_datatable menjadi build_datatable

### DIFF
--- a/app/MyModel.php
+++ b/app/MyModel.php
@@ -890,7 +890,8 @@ class MyModel extends Model
         }
 
         if (isset($params['pre_datatable'])) {
-            $pre_action_datatable = $params['pre_datatable'];
+            $params['build_datatable'] = $params['pre_datatable'];
+            $pre_action_datatable = $params['build_datatable'];
             $datatable = $pre_action_datatable($datatable);
         }
 

--- a/app/MyModel.php
+++ b/app/MyModel.php
@@ -891,8 +891,11 @@ class MyModel extends Model
 
         if (isset($params['pre_datatable'])) {
             $params['build_datatable'] = $params['pre_datatable'];
-            $pre_action_datatable = $params['build_datatable'];
-            $datatable = $pre_action_datatable($datatable);
+        }
+
+        if(isset($params['build_datatable'])){
+            $build_action_datatable = $params['build_datatable'];
+            $datatable = $build_action_datatable($datatable);
         }
 
         try {


### PR DESCRIPTION
mengubah pre_datatable menjadi build_datatable supaya lebih mudah dipahami. karna fungsi dari param tersebut adalah untuk membentuk susunan kolom datatable (yajra datatable) atau menggunakan function-function yang disediakan oleh yajra datatable. akan tetapi pre_datatable tetap bisa digunakan bagi yang sudah terlanjur.